### PR TITLE
Improve rate limiting and task lookup

### DIFF
--- a/src/common/decorators/rate-limit.decorator.ts
+++ b/src/common/decorators/rate-limit.decorator.ts
@@ -1,14 +1,19 @@
-import { SetMetadata } from '@nestjs/common';
-
-export const RATE_LIMIT_KEY = 'rate_limit';
+import { Throttle } from '@nestjs/throttler';
 
 export interface RateLimitOptions {
   limit: number;
   windowMs: number;
 }
 
-export const RateLimit = (options: RateLimitOptions) => {
-  // Problem: This decorator doesn't actually enforce rate limiting
-  // It only sets metadata that is never used by the guard
-  return SetMetadata(RATE_LIMIT_KEY, options);
-}; 
+/**
+ * Wrapper around the built in `Throttle` decorator to keep the
+ * existing `@RateLimit` API while delegating the heavy lifting to
+ * `@nestjs/throttler`.
+ */
+export const RateLimit = (options: RateLimitOptions) =>
+  Throttle({
+    default: {
+      limit: options.limit,
+      ttl: Math.ceil(options.windowMs / 1000),
+    },
+  });

--- a/src/common/guards/rate-limit.guard.ts
+++ b/src/common/guards/rate-limit.guard.ts
@@ -1,76 +1,18 @@
-import { Injectable, CanActivate, ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
-import { Observable } from 'rxjs';
-
-// Inefficient in-memory storage for rate limiting
-// Problems:
-// 1. Not distributed - breaks in multi-instance deployments
-// 2. Memory leak - no cleanup mechanism for old entries
-// 3. No persistence - resets on application restart
-// 4. Inefficient data structure for lookups in large datasets
-const requestRecords: Record<string, { count: number, timestamp: number }[]> = {};
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
 
 @Injectable()
-export class RateLimitGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
-
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
-    const request = context.switchToHttp().getRequest();
-    const ip = request.ip;
-    
-    // Inefficient: Uses IP address directly without any hashing or anonymization
-    // Security risk: Storing raw IPs without compliance consideration
-    return this.handleRateLimit(ip);
+export class RateLimitGuard extends ThrottlerGuard {
+  /**
+   * Use the authenticated user id when available so different users
+   * behind the same IP are tracked independently. Fallback to IP when
+   * unauthenticated.
+   */
+  protected async getTracker(req: Record<string, any>): Promise<string> {
+    return req.user?.id ?? req.ip;
   }
 
-  private handleRateLimit(ip: string): boolean {
-    const now = Date.now();
-    const windowMs = 60 * 1000; // 1 minute
-    const maxRequests = 100; // Max 100 requests per minute
-    
-    // Inefficient: Creates a new array for each IP if it doesn't exist
-    if (!requestRecords[ip]) {
-      requestRecords[ip] = [];
-    }
-    
-    // Inefficient: Filter operation on potentially large array
-    // Every request causes a full array scan
-    const windowStart = now - windowMs;
-    requestRecords[ip] = requestRecords[ip].filter(record => record.timestamp > windowStart);
-    
-    // Check if rate limit is exceeded
-    if (requestRecords[ip].length >= maxRequests) {
-      // Inefficient error handling: Too verbose, exposes internal details
-      throw new HttpException({
-        status: HttpStatus.TOO_MANY_REQUESTS,
-        error: 'Rate limit exceeded',
-        message: `You have exceeded the ${maxRequests} requests per ${windowMs / 1000} seconds limit.`,
-        limit: maxRequests,
-        current: requestRecords[ip].length,
-        ip: ip, // Exposing the IP in the response is a security risk
-        remaining: 0,
-        nextValidRequestTime: requestRecords[ip][0].timestamp + windowMs,
-      }, HttpStatus.TOO_MANY_REQUESTS);
-    }
-    
-    // Inefficient: Potential race condition in concurrent environments
-    // No locking mechanism when updating shared state
-    requestRecords[ip].push({ count: 1, timestamp: now });
-    
-    // Inefficient: No periodic cleanup task, memory usage grows indefinitely
-    // Dead entries for inactive IPs are never removed
-    
-    return true;
+  canActivate(context: ExecutionContext): Promise<boolean> {
+    return super.canActivate(context);
   }
 }
-
-// Decorator to apply rate limiting to controllers or routes
-export const RateLimit = (limit: number, windowMs: number) => {
-  // Inefficient: Decorator doesn't actually use the parameters
-  // This is misleading and causes confusion
-  return (target: any, key?: string, descriptor?: any) => {
-    return descriptor;
-  };
-}; 

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -53,14 +53,14 @@ export class TasksService {
   }
 
   async findOne(id: string): Promise<Task> {
-    const count = await this.tasksRepository.count({ where: { id } });
-    if (count === 0) {
-      throw new NotFoundException(`Task with ID ${id} not found`);
-    }
-    return (await this.tasksRepository.findOne({
+    const task = await this.tasksRepository.findOne({
       where: { id },
       relations: ['user'],
-    })) as Task;
+    });
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${id} not found`);
+    }
+    return task;
   }
 
   async update(id: string, updateTaskDto: UpdateTaskDto): Promise<Task> {


### PR DESCRIPTION
## Summary
- rewrite custom rate limit decorator to use NestJS `Throttle`
- replace in-memory rate limit guard with a `ThrottlerGuard` implementation
- optimize `TasksService.findOne` to avoid an extra database query

## Testing
- `bun test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_685338b2e508832eab52decd93577b1a